### PR TITLE
Add EncDotNet S-100 Viewer to supporting products

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This section lists software applications which provide the capability to create 
 |                      |[NIWC S-100 ShoreECDIS] **`Free`** |Ed.2.0.0  | Ed.3.0.0  | Ed.2.0.0  | Ed.2.0.0  |Ed.2.0.0  | Ed.2.0.0  |
 | I4Insight            |[dKart S-101 Converter] **`Free`** |Ed.1.0.0  |           |           |           |          |           |
 | Teledyne Geospatial  |[CARIS Easy view]   **`Free`**     |Ed.2.0.0  | Ed.3.0.0  |           |           |          |           |
+| EncDotNet            |[EncDotNet S-100 Viewer] **`Free`** |Ed.2.0.0  | Ed.3.0.0  | Ed.2.0.0  | Ed.2.0.0  |Ed.2.0.0  | Ed.2.0.0  |
 |                      |[HPD] and [Composer]               |Ed.2.0.0  |           |           |           |          |           |
 |                      |[BASE Editor]                      |          | Ed.3.0.0  |           |           |          |           |
 |                      |[CARIS Cloud]                      |          | Support   |           |Support    |          |           |
@@ -69,6 +70,7 @@ This section lists software applications which provide the capability to create 
 [Composer]:https://www.teledynecaris.com/en/products/s-100-composer/
 [BASE Editor]:https://www.teledynecaris.com/en/products/base-editor/
 [CARIS Cloud]:https://www.teledynecaris.com/en/products/caris-cloud/
+[EncDotNet S-100 Viewer]:https://github.com/philliphoff/EncDotNet.S100
 [S-421 Converter]:https://s421creator.ecc.no/index.html
 
 ### Test Datasets


### PR DESCRIPTION
Adds the EncDotNet S-100 Viewer (free, cross-platform) to the Product Software Support table, grouped with the other free products.

Supported products: S-101 (Ed.2.0.0), S-102 (Ed.3.0.0), S-104 (Ed.2.0.0), S-111 (Ed.2.0.0), S-124 (Ed.2.0.0), S-129 (Ed.2.0.0).

Project: https://github.com/philliphoff/EncDotNet.S100